### PR TITLE
Fixed the code for Visual Studio builds.

### DIFF
--- a/Block.cpp
+++ b/Block.cpp
@@ -15,7 +15,12 @@ Block::Block(uint32_t nIndexIn, const string &sDataIn) : _nIndex(nIndexIn), _sDa
 
 void Block::MineBlock(uint32_t nDifficulty)
 {
-    char cstr[nDifficulty + 1];
+#if (_MSC_VER >= 1500)
+	char* cstr = new char[nDifficulty + 1];
+#else
+	char cstr[nDifficulty + 1];
+#endif
+
     for (uint32_t i = 0; i < nDifficulty; ++i)
     {
         cstr[i] = '0';
@@ -32,6 +37,10 @@ void Block::MineBlock(uint32_t nDifficulty)
     while (sHash.substr(0, nDifficulty) != str);
 
     cout << "Block mined: " << sHash << endl;
+
+#if (_MSC_VER >= 1500)
+	delete[] cstr;
+#endif
 }
 
 inline string Block::_CalculateHash() const

--- a/Block.h
+++ b/Block.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <iostream>
 #include <sstream>
+#include <time.h>
 
 using namespace std;
 


### PR DESCRIPTION
In Visual Studio you cannot define char arrays without constant expressions, and time.h include was missing.